### PR TITLE
Ability to send multiple log entries per single SQS message

### DIFF
--- a/beaver/config.py
+++ b/beaver/config.py
@@ -100,7 +100,7 @@ class BeaverConfig():
             'sqs_aws_region': 'us-east-1',
             'sqs_aws_queue': '',
             'sqs_aws_queue_owner_acct_id': '',
-            'sqs_bulk_lines': false,
+            'sqs_bulk_lines': False,
             'kinesis_aws_access_key': '', 
             'kinesis_aws_secret_key': '', 
             'kinesis_aws_region': 'us-east-1', 

--- a/beaver/config.py
+++ b/beaver/config.py
@@ -100,6 +100,7 @@ class BeaverConfig():
             'sqs_aws_region': 'us-east-1',
             'sqs_aws_queue': '',
             'sqs_aws_queue_owner_acct_id': '',
+            'sqs_bulk_lines': false,
             'kinesis_aws_access_key': '', 
             'kinesis_aws_secret_key': '', 
             'kinesis_aws_region': 'us-east-1', 

--- a/beaver/transports/sqs_transport.py
+++ b/beaver/transports/sqs_transport.py
@@ -2,10 +2,10 @@
 import boto.sqs
 import uuid
 
-from boto.sqs.message import Message
+from boto.sqs.message import Message, RawMessage
 from beaver.transports.base_transport import BaseTransport
 from beaver.transports.exception import TransportException
-
+from sys import getsizeof
 
 class SqsTransport(BaseTransport):
 
@@ -14,16 +14,13 @@ class SqsTransport(BaseTransport):
 
         self._access_key = beaver_config.get('sqs_aws_access_key')
         self._secret_key = beaver_config.get('sqs_aws_secret_key')
-        self._profile = beaver_config.get('sqs_aws_profile_name')
         self._region = beaver_config.get('sqs_aws_region')
         self._queue_name = beaver_config.get('sqs_aws_queue')
         self._queue_owner_acct_id = beaver_config.get('sqs_aws_queue_owner_acct_id')
+        self._bulk_lines = beaver_config.get('sqs_bulk_lines')
 
         try:
-            if self._profile:
-                self._connection = boto.sqs.connect_to_region(self._region,
-                                                              profile_name=self._profile)
-            elif self._access_key is None and self._secret_key is None:
+            if self._access_key is None and self._secret_key is None:
                 self._connection = boto.sqs.connect_to_region(self._region)
             else:
                 self._connection = boto.sqs.connect_to_region(self._region,
@@ -50,35 +47,73 @@ class SqsTransport(BaseTransport):
         if kwargs.get('timestamp', False):
             del kwargs['timestamp']
 
-        message_batch = []
+	if self._bulk_lines:
+	    message_batch = ''
+            message_count = 0
+	else:
+            message_batch = []
+
         message_batch_size = 0
         message_batch_size_max = 250000 # Max 256KiB but leave some headroom
 
         for line in lines:
-            m = Message()
-            m.set_body(self.format(filename, line, timestamp, **kwargs))
-            message_size = len(m)
+	    if self._bulk_lines:
+		m = self.format(filename, line, timestamp, **kwargs)
+                message_size = getsizeof(m)
+	    else:
+                m = Message()
+                m.set_body(self.format(filename, line, timestamp, **kwargs))
+                message_size = len(m)
 
             if (message_size > message_batch_size_max):
                 self._logger.debug('Dropping the message as it is too large to send ({0} bytes)'.format(message_size))
                 continue
 
-            # SQS can only handle up to 10 messages in batch send and it can not exceed 256KiB (see above)
             # Check the new total size before adding a new message and don't try to send an empty batch
-            if (len(message_batch) > 0) and (((message_batch_size + message_size) >= message_batch_size_max) or (len(message_batch) == 10)):
-                self._logger.debug('Flushing {0} messages to SQS queue {1} bytes'.format(len(message_batch), message_batch_size))
-                self._send_message_batch(message_batch)
-                message_batch = []
-                message_batch_size = 0
+	    if self._bulk_lines and (len(message_batch) > 0) and (((message_batch_size + message_size) >= message_batch_size_max)):
+                    self._logger.debug('Flushing {0} messages to SQS queue {1} bytes'.format(message_count, message_batch_size))
+                    self._send_message(message_batch)
+                    message_batch = ''
+                    message_count = 0
+                    message_batch_size = 0
+
+            # SQS can only handle up to 10 messages in batch send and it can not exceed 256KiB (see above)
+            elif (len(message_batch) > 0) and (((message_batch_size + message_size) >= message_batch_size_max) or (len(message_batch) == 10)):
+                    self._logger.debug('Flushing {0} messages to SQS queue {1} bytes'.format(len(message_batch), message_batch_size))
+                    self._send_message_batch(message_batch)
+                    message_batch = []
+                    message_batch_size = 0
 
             message_batch_size = message_batch_size + message_size
-            message_batch.append((uuid.uuid4(), self.format(filename, line, timestamp, **kwargs), 0))
+	    if self._bulk_lines:
+		message_batch += '{0},'.format(m)
+                message_count += 1
+	    else:
+                message_batch.append((uuid.uuid4(), self.format(filename, line, timestamp, **kwargs), 0))
 
         if len(message_batch) > 0:
-            self._logger.debug('Flushing the last {0} messages to SQS queue {1} bytes'.format(len(message_batch), message_batch_size))
-            self._send_message_batch(message_batch)
+	    if self._bulk_lines:
+                self._logger.debug('Flushing the last {0} messages to SQS queue {1} bytes'.format(message_count, message_batch_size))
+                self._send_message(message_batch)
+	    else:
+                self._logger.debug('Flushing the last {0} messages to SQS queue {1} bytes'.format(len(message_batch), message_batch_size))
+                self._send_message_batch(message_batch)
 
         return True
+
+    def _send_message(self, msg):
+        try:
+            msg = '[{0}]'.format(msg.rstrip(','))
+            m = RawMessage()
+            m.set_body(msg)
+            result = self._queue.write(m)
+            if not result:
+                self._logger.error('Error occurred sending message to SQS queue {0}. result: {1}'.format(
+                    self._queue_name, result))
+                raise TransportException('Error occurred sending message to queue {0}'.format(self._queue_name))
+        except Exception, e:
+            self._logger.exception('Exception occurred sending message to SQS queue')
+            raise TransportException(e.message)
 
     def _send_message_batch(self, message_batch):
         try:

--- a/beaver/transports/sqs_transport.py
+++ b/beaver/transports/sqs_transport.py
@@ -14,12 +14,16 @@ class SqsTransport(BaseTransport):
 
         self._access_key = beaver_config.get('sqs_aws_access_key')
         self._secret_key = beaver_config.get('sqs_aws_secret_key')
+        self._profile = beaver_config.get('sqs_aws_profile_name')
         self._region = beaver_config.get('sqs_aws_region')
         self._queue_name = beaver_config.get('sqs_aws_queue')
         self._queue_owner_acct_id = beaver_config.get('sqs_aws_queue_owner_acct_id')
         self._bulk_lines = beaver_config.get('sqs_bulk_lines')
 
         try:
+            if self._profile:
+                self._connection = boto.sqs.connect_to_region(self._region,
+                                                              profile_name=self._profile)
             if self._access_key is None and self._secret_key is None:
                 self._connection = boto.sqs.connect_to_region(self._region)
             else:

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -87,6 +87,7 @@ Beaver can optionally get data from a ``configfile`` using the ``-c`` flag. This
 * sqs_aws_region: Default ``us-east-1``. AWS Region
 * sqs_aws_queue: SQS queue (must exist)
 * sqs_aws_queue_owner_acct_id: Optional. Defaults ``None``. Account ID or Principal allowed to write to queue
+* sqs_bulk_lines: Optional. Send multiple log entries in a single SQS message (cost saving benefit on larger environments)
 * kinesis_aws_access_key: Can be left blank to use IAM roles or AWS_ACCESS_KEY_ID environment variable (see: https://github.com/boto/boto#getting-started-with-boto)
 * kinesis_aws_secret_key: Can be left blank to use IAM Roles or AWS_SECRET_ACCESS_KEY environment variable (see: https://github.com/boto/boto#getting-started-with-boto)
 * kinesis_aws_region: Default ``us-east-1``. AWS Region


### PR DESCRIPTION
https://github.com/josegonzalez/python-beaver/pull/355

In larger environments the requests made to SQS to read\write messages can soon add up, coupled with AWS charging in 64kb chunks, sending (and LogStash retrieving) single log entries per SQS message can soon become expensive.

This change adds a config flag sqs_bulk_lines (as to have no adverse affect to current deployments) to allow users to group messages in a similar way to the write_bulk function currently work (grouping messages up to a max of 256kb), only they are sent as an array list in a single SQS message rather than being sent as separate messages in one transaction.